### PR TITLE
Manage closed remote connections

### DIFF
--- a/lib/webkit_remote/rpc.rb
+++ b/lib/webkit_remote/rpc.rb
@@ -100,11 +100,13 @@ class Rpc
   # @return [Hash<String, Object>, nil] a Hash containing the RPC result if an
   #     expected RPC response was received; nil if an RPC notice was received
   def receive_message(expected_id)
+    json = nil
+
     ::Timeout::timeout(READ_TIMEOUT) do
       json = @web_socket.recv_frame
     end
 
-    if json == :closed do
+    if json == :closed
       close
       raise RuntimeError, 'Connection to remote Webkit has been closed unexpectedly'
     end

--- a/lib/webkit_remote/rpc.rb
+++ b/lib/webkit_remote/rpc.rb
@@ -106,7 +106,7 @@ class Rpc
 
     if json == :closed do
       close
-      raise RuntimeError, 'Connection to remote Chrome has been closed unexpectedly'
+      raise RuntimeError, 'Connection to remote Webkit has been closed unexpectedly'
     end
 
     begin
@@ -136,6 +136,8 @@ class Rpc
       close
       raise RuntimeError, "Unexpected / invalid RPC message #{data.inspect}"
     end
+  rescue ::Timeout::Error => e
+    raise RuntimeError, "No response received from remote Webkit in #{READ_TIMEOUT} seconds"
   end
   private :receive_message
 end  # class WebkitRemote::Rpc


### PR DESCRIPTION
This MR tries to avoid the closed connections to the Webkit remote debug socket, using the changes also described in https://github.com/pwnall/ws_sync_client/pull/1

It also adds a timeout on receive phase, as we have seen long waiting for RPC responses that never come. That part should be probably avoided now that closed connections are handled correctly, but this ensures that if there are no response within 120 seconds, an exception is raised.